### PR TITLE
修复切换按钮一直为 play 状态

### DIFF
--- a/js/vrouter-local.js
+++ b/js/vrouter-local.js
@@ -154,6 +154,7 @@ class VRouter {
 
     return Promise.all([
       this.localExec(cmd1).then((output) => {
+        output = output.replace(/(\r?\n|\r).+/, '')
         return Promise.resolve((output && output.trim()) || '')
       }),
       this.localExec(cmd2).then((output) => {


### PR DESCRIPTION
`gw = "10.19.28.37↵fe80::%utun0" `
避免这种情况导致切换按钮没有按预期工作